### PR TITLE
fix(LuaService, CoerceJavaToLua): prevent foreground service crash and thread-safe coercion

### DIFF
--- a/app/src/main/java/org/luaj/lib/jse/CoerceJavaToLua.java
+++ b/app/src/main/java/org/luaj/lib/jse/CoerceJavaToLua.java
@@ -11,11 +11,12 @@ import org.luaj.LuaInteger;
 import org.luaj.LuaString;
 import org.luaj.LuaValue;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 
 public class CoerceJavaToLua {
-    private static final Map<Class<?>, Coercion> a = new HashMap<>();
+    // Trying ConcurrentHashMap instead of HashMap — probably overkill, but better to be safe with threading.
+    private static final Map<Class<?>, Coercion> a = new ConcurrentHashMap<>();
     static final Coercion b;
     static final Coercion c;
     static final Coercion d;


### PR DESCRIPTION
- Fix LuaService failing to start foreground service on Android 8+
- Improve thread safety in CoerceJavaToLua coercion map using ConcurrentHashMap, attempt to resolve rare type coercion failures under multi-threaded execution (e.g., xTask)